### PR TITLE
Feature/34 fix menu pipes

### DIFF
--- a/src/SmartGit/Manual/AddOns/Distributed-Reviews-add-on-.md
+++ b/src/SmartGit/Manual/AddOns/Distributed-Reviews-add-on-.md
@@ -1,15 +1,18 @@
 # Distributed Reviews (add-on)
 
-The *Distributed Reviews* add-on allows your team to create a *Pull Request* from one branch to another and to *comment* on pull requests and individual commits. Contrary to *centralized* code reviewing systems like GitHub, no dedicated server is required: all review metadata is stored in the Git repository itself and distributed the same way as your primary content/commits. This gives you all the benefits of Git: you can work offline and you can prepare your pull requests and comments locally and only push them when ready, or discard them if you change your mind, without affecting anyone else.
+The *Distributed Reviews* add-on allows your team to create a *Pull Request* from one branch to another and to *comment* on pull requests and individual commits. 
+Contrary to *centralized* code reviewing systems like GitHub, no dedicated server is required: all review metadata is stored in the Git repository itself and distributed the same way as your primary content/commits. 
+This gives you all the benefits of Git: you can work offline and you can prepare your pull requests and comments locally and only push them when ready, or discard them if you change your mind, without affecting anyone else.
 
 ## Initialization
 
-To initialize the Review system for your local repository invoke
-**Review\|Configure**.
+To initialize the Review system for your local repository invoke **Review \| Configure**.
 
-SmartGit will query all currently configured *remotes* to see whether any of them already contains a *Review database*. If this is the case, SmartGit will clone this database and *connect* the local Review system to it. If none of the remotes contains a Review database, a completely new database will be created and the [users database](#users) will be populated from the repository log.
+SmartGit will query all currently configured *remotes* to see whether any of them already contains a *Review database*. 
+If this is the case, SmartGit will clone this database and *connect* the local Review system to it. 
+If none of the remotes contains a Review database, a completely new database will be created and the [users database](#users) will be populated from the repository log.
 
-For a *shared* repository (including all its *clones*), the initialization of a completely new database should only be done once, e.g. when starting to introduce the Review system for your project. This will usually happen in one of the clones. After the initialization of the local repository, invoke **Review\|Configure** and select
+For a *shared* repository (including all its *clones*), the initialization of a completely new database should only be done once, e.g. when starting to introduce the Review system for your project. This will usually happen in one of the clones. After the initialization of the local repository, invoke **Review \| Configure** and select
 **Initialize a Remote** to push your Review database back to the selected remote, thus initializing this repository as well. From this point on, **Review\|Configure** can be invoked in all other clones of the shared repository to clone and connect to the same Review database.
 
 ## Workflows
@@ -23,11 +26,11 @@ To create a Pull Request, select your *feature branch* in the
 **Branches** view and invoke **Create Pull Request** from the context menu. In the upcoming dialog, select the **target** branch and a
 **Message** describing the purpose of the Pull Request. It's recommended to specify at least one **Assignee**, who is the right person to review and integrate this Pull Request. The Pull Request will be highlighted to all assignees in the **Branches** view (in the Project as well as the Log window).
 
-Once the Pull Request has been created, it is in *pending state* and will show up in the **Pull Requests** category of the **Branches** view as *local only*. It will be published, i.e. sent to the remote repository, for the next time you invoke **Push**. Alternatively, you can manually force publishing the Pull Request using **Review\|Sync**.
+Once the Pull Request has been created, it is in *pending state* and will show up in the **Pull Requests** category of the **Branches** view as *local only*. It will be published, i.e. sent to the remote repository, for the next time you invoke **Push**. Alternatively, you can manually force publishing the Pull Request using **Review \| Sync**.
 
 ### Reviewing and integrating a Pull Request
 
-Once a Pull Request is published (i.e. present in the remote repository), it will be fetched by all other users for their next invocation of **Pull** or by doing **Review\|Sync** manually. If you are amongst the **Assignees** of a Pull Request, it will be highlighted to you in the **Branches** view.
+Once a Pull Request is published (i.e. present in the remote repository), it will be fetched by all other users for their next invocation of **Pull** or by doing **Review \| Sync** manually. If you are amongst the **Assignees** of a Pull Request, it will be highlighted to you in the **Branches** view.
 
 To review or integrate a Pull Request, open the Log and select and reveal the Pull Request from the **Pull Requests** category. The Pull Request is represented by a merge commit which connects its source (the feature branch) with the *merge base* between the source and the Pull Request's target (probably `master` or `develop`). When selecting this Pull Request commit in the **Commits** graph, the **Files** view will show all affected files of the Pull Request and you can drill down to content changes in the **Changes** view.
 
@@ -70,7 +73,7 @@ and switch to the **Commit** view. Here you will also be able to display older h
 
 After integrating or closing a pull request, the pull request will still be present in the Review database, but by default be hidden from the
 **Branches** view. To display *closed* pull requests, select
-**Review\|Show Closed Pull Requests**.
+**Review \| Show Closed Pull Requests**.
 
 As long as a pull request is still present in the database, SmartGit maintains *refs* pointing to all of its heads, thus preventing Git from garbage collecting the corresponding commits, see [Historic Commit Refs](#historic-commit-refs). Only by invoking **Delete** on a *closed*
 pull request, it will be removed from the database and correspondings
@@ -119,13 +122,15 @@ The resolution of these 'conflicts' is done by the user when editing the entity:
 From the difference between `refs/meta/smartgit/reviews` and
 `refs/meta/smartgit/remotes/<remote-id>/reviews`, SmartGit will derive which pull requests and comments ('entities') are *local*.
 
-After pushing regular commits to a certain remote or when invoking
-**Review\|Sync**, SmartGit will include only those entities for which their referred commits (or refs) are already present in the corresponding remote. In this way, you can create local commits together with local review data and push them only all at once. Before pushing local review data, SmartGit will squash all your local review tree commits into a single commit: this especially means that additions followed by deletions of certain entities or some back and forth while editing entities will be skipped. Thus, similar as for 'normal' Git commits, you have freedom in how to assemble your review data; only the final result will matter.
+After pushing regular commits to a certain remote or when invoking **Review \| Sync**, SmartGit will include only those entities for which their referred commits (or refs) are already present in the corresponding remote. 
+In this way, you can create local commits together with local review data and push them only all at once. 
+Before pushing local review data, SmartGit will squash all your local review tree commits into a single commit: this especially means that additions followed by deletions of certain entities or some back and forth while editing entities will be skipped. 
+Thus, similar as for 'normal' Git commits, you have freedom in how to assemble your review data; only the final result will matter.
 
 ### Historic Commit Refs
 
-SmartGit maintains a list of special refs
-`refs/meta/smartgit/commits/<sha>` for all commits which are representing pull request heads (current heads as well as historic heads) and for all commits to which a comment is assigned. This happens to (1) make such commits *pushable* and *pullable* and (2) to preserve them from being garbage-collected by Git: while on the client-side, the
+SmartGit maintains a list of special refs `refs/meta/smartgit/commits/<sha>` for all commits which are representing pull request heads (current heads as well as historic heads) and for all commits to which a comment is assigned. 
+This happens to (1) make such commits *pushable* and *pullable* and (2) to preserve them from being garbage-collected by Git: while on the client-side, the
 *reflog*-files are usually preventing a garbage collection, this is by default not the case on the server-side.
 
 By default, historic commit refs will be removed, once the corresponding entity will be removed from the database. To disabling pruning of such commits, you have to unset the `prune-commit-refs` option in the review database:
@@ -149,9 +154,10 @@ git commit -m "configuration changed to prune obsolete commit refs"
 git update-ref refs/meta/smartgit/reviews `git rev-parse HEAD` 
 ```
 
-- Finally, sync this change using SmartGit's **Review\|Sync**.
+- Finally, sync this change using SmartGit's **Review \| Sync**.
 
-Once this change has been pulled to a different clone for which Distributed Reviews are enabled, obsolete refs won't be removed anymore from now on. To confirm that the option actually works, you may invoke following command *before* adding and *after* removing a comment locally:
+Once this change has been pulled to a different clone for which Distributed Reviews are enabled, obsolete refs won't be removed anymore from now on. 
+To confirm that the option actually works, you may invoke following command *before* adding and *after* removing a comment locally:
 
 ``` text
 git show-ref | grep -c refs/meta/smartgit/commits        
@@ -161,7 +167,8 @@ If the displayed number remains increased after having removed the comment, you 
 
 ## Disposing your local Review Database
 
-Sometimes it may be desirable to reinitialize your local review database from the server's database. For that, it's necessary to first dispose your local database using **Review\|Configure** and select **Dispose Database** there.
+Sometimes it may be desirable to reinitialize your local review database from the server's database. 
+For that, it's necessary to first dispose your local database using **Review \| Configure** and select **Dispose Database** there.
 
 #### Note
 
@@ -177,12 +184,13 @@ To get rid of Distributed Reviews data not just for your local clone, but also f
 - on the server, delete all `refs/meta/smartgit/*`-refs
     - usually there are no packed refs on the server, hence you can simply delete these refs from the file system
     - alternatively, if you do not have access to the server's file system, you may use `git push --delete <remote> <ref>` to delete them remotely
-- on every clone, invoke **Review\|Configure** and select **Dispose Database**
+- on every clone, invoke **Review \| Configure** and select **Dispose Database**
 
 ## Customizing the pull request integration message
 
-The default message which will be set for the **Integrate Pull Request**
-dialog can be customized by using a message template. The message template will be specified using [Low-level property](../GUI/AdvancedSettings/Low-Level-Properties.md) `smartgit.reviews.integrateMessageTemplate`. Following variables can be used:
+The default message which will be set for the **Integrate Pull Request** dialog can be customized by using a message template. 
+The message template will be specified using [Low-level property](../GUI/AdvancedSettings/Low-Level-Properties.md) `smartgit.reviews.integrateMessageTemplate`. 
+The following variables can be used:
 
 - `${id}:` the short pull request ID
 - `${message}:` the entire pull request message (including new lines)

--- a/src/SmartGit/Manual/AddOns/Distributed-Reviews-add-on-.md
+++ b/src/SmartGit/Manual/AddOns/Distributed-Reviews-add-on-.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Distributed-Reviews-add-on-
-  - /SmartGit/Manual/Distributed-Reviews-add-on-.html
----
-
 # Distributed Reviews (add-on)
 
 The *Distributed Reviews* add-on allows your team to create a *Pull Request* from one branch to another and to *comment* on pull requests and individual commits. Contrary to *centralized* code reviewing systems like GitHub, no dedicated server is required: all review metadata is stored in the Git repository itself and distributed the same way as your primary content/commits. This gives you all the benefits of Git: you can work offline and you can prepare your pull requests and comments locally and only push them when ready, or discard them if you change your mind, without affecting anyone else.

--- a/src/SmartGit/Manual/AddOns/Server-side-component.md
+++ b/src/SmartGit/Manual/AddOns/Server-side-component.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Server-side-component
-  - /SmartGit/Manual/Server-side-component.html
----
-
 # Server-side component
 
 The Distributes Reviews server-side component is **optional**, and is useful where your team does not have access to an interactive Pull Request review system such as GitHub, GitLab, or Azure DevOps. Once installed and configured, it will track changes to the review meta data and send appropriate emails to affected users.

--- a/src/SmartGit/Manual/AddOns/index.md
+++ b/src/SmartGit/Manual/AddOns/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/AddOns
----
 # Add-Ons to SmartGit
 
 SmartGit provides the following optional Add-Ons which can be used to enhance your SmartGit installation:

--- a/src/SmartGit/Manual/DevelopmentProcesses/Git-Flow-Light.md
+++ b/src/SmartGit/Manual/DevelopmentProcesses/Git-Flow-Light.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Git-Flow-Light
-  - /SmartGit/Manual/Git-Flow-Light.html
----
-
 # Git-Flow Light
 
 Git-Flow Light is a SmartGit-specific subset of Git-Flow, simplifying the branching model to just one long-lived **Development** trunk branch and short-lived **Feature** branches.

--- a/src/SmartGit/Manual/DevelopmentProcesses/Git-Flow.md
+++ b/src/SmartGit/Manual/DevelopmentProcesses/Git-Flow.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Git-Flow
-  - /SmartGit/Manual/Git-Flow.html
----
-
 # Git-Flow
 
 ## Overview

--- a/src/SmartGit/Manual/DevelopmentProcesses/index.md
+++ b/src/SmartGit/Manual/DevelopmentProcesses/index.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/DevelopmentProcesses
-  - /SmartGit/Manual/DevelopmentProcesses.html
----
-
 # Support for Standard Development Processes in SmartGit
 
 Although Git's flexibility allows for almost unlimited variations in how teams work within a repository, most developers are familiar with standard branching, merging, and rebasing strategies that promote systematic and productive workflows.

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
@@ -81,17 +81,19 @@ To hide a specific page, set the corresponding property to `false`.
 
 ### smartgit.contactSupportEnabled
 
-Set this option to `false` to hide the menu item **Help\|Contact Support**.
+Set this option to `false` to hide the menu item **Help \| Contact Support**.
 
 ### smartgit.registerEnabled
 
-Set this option to `false` to hide the menu item **Help\|Register**.
+Set this option to `false` to hide the menu item **Help \| Register**.
 
 ## Update Check
 
 ### smartgit.updateCheck.enabled
 
-Set to `false` to disable the automatic checking and disallow the manual checking for new program versions by hiding the corresponding menu items **Help\|Check for New Version** and **Help\|Check for Latest Build**. You should only turn this check off for network installations where SmartGit users may not be able to perform the update themselves. When settings this option, you will probably also want to hide the corresponding page from the **Preferences**, using [smartgit.preferences.updateCheck.visible](#smartgitpreferencescategoryvisible).
+Set to `false` to disable the automatic checking and disallow the manual checking for new program versions by hiding the corresponding menu items **Help \| Check for New Version** and **Help \| Check for Latest Build**. 
+You should only turn this check off for network installations where SmartGit users may not be able to perform the update themselves. 
+When settings this option, you will probably also want to hide the corresponding page from the **Preferences**, using [smartgit.preferences.updateCheck.visible](#smartgitpreferencescategoryvisible).
 
 Note that this will also disable notifications of new bugfix releases which you can upgrade to for free and which improve the stability or reliability of SmartGit.
 
@@ -99,26 +101,30 @@ If you just want to switch off automatic checking, use `smartgit.updateCheck.aut
 
 ### smartgit.updateCheck.automatic
 
-Set to `false` to disable the **automatic** check for new versions on a global level which can be convenient e.g. for network installations. To disable the check for an individual installation/user, better do that in the **Preferences**, section **SmartGit Updates**.
+Set to `false` to disable the **automatic** check for new versions on a global level which can be convenient e.g. for network installations. 
+To disable the check for an individual installation/user, better do that in the **Preferences**, section **SmartGit Updates**.
 
 ### smartgit.updateCheck.alwaysUpgradeToLatestBuild
 
 Set to `true` to make SmartGit check for the availability of a new *latest build* on start up.
-*Latest Builds* are the "bleeding edge" builds between subsequent (minor) *release* builds, like between version 8.0.1 and 8.0.2 or 8.1 preview 3 and 8.1 preview 4. They will contain the latest improvements and bugfixes. Usually we will ask you to manually fetch the latest build using **Help\|Check for Latest Builds**.
+*Latest Builds* are the "bleeding edge" builds between subsequent (minor) *release* builds, like between version 8.0.1 and 8.0.2 or 8.1 preview 3 and 8.1 preview 4. They will contain the latest improvements and bugfixes. 
+Usually we will ask you to manually fetch the latest build using **Help \| Check for Latest Builds**.
 
 ### smartgit.updateCheck.checkForLatestBuildVisible
 
-Set to `false` to hide **Help\|Check for Latest Build**.
+Set to `false` to hide **Help \| Check for Latest Build**.
 
 ### smartgit.installation.update.workingArea
 
-Use this property to customize the [program updater](../../Installation/Installation-and-Files.md)'s temporary directory, which is by default located in your home directory/profile. This should only be necessary if updating is not possible due to (file system) restrictions in this default directory, e.g. if execution of files is prevented by the system. On Windows, paths have to be specified using forward-slashes, like `c:/temp`.
+Use this property to customize the [program updater](../../Installation/Installation-and-Files.md)'s temporary directory, which is by default located in your home directory/profile. This should only be necessary if updating is not possible due to (file system) restrictions in this default directory, e.g. if execution of files is prevented by the system. 
+On Windows, paths have to be specified using forward-slashes, like `c:/temp`.
 
 ## Bug Reporting
 
 ### smartgit.disableBugReporting
 
-Set to `true` to disable sending of [crash footprints](../Bug-Reports.md) (even if configured in the **Preferences**) and skip the option to send bug reports to us. When setting this option, you will probably also want to hide the corresponding page from the **Preferences**, see [smartgit.preferences.bugReports.visible](#smartgitpreferencescategoryvisible).
+Set to `true` to disable sending of [crash footprints](../Bug-Reports.md) (even if configured in the **Preferences**) and skip the option to send bug reports to us. 
+When setting this option, you will probably also want to hide the corresponding page from the **Preferences**, see [smartgit.preferences.bugReports.visible](#smartgitpreferencescategoryvisible).
 
 #### Warning
 

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
@@ -9,7 +9,7 @@ redirect_from:
 In addition to the options available in the [SmartGit Preferences](../Preferences/index.md), additional customization options are accessible through the SmartGit Properties file (`smartgit.properties`). 
 This article describes these additional properties.
 
-Most low-level properties below can be edited directly in the **Edit | Preferences** settings dialog under the **Low-Level Properties** section. 
+Most low-level properties below can be edited directly in the **Edit \| Preferences** settings dialog under the **Low-Level Properties** section. 
 Changing these values updates the `smartgit.properties` file, which is located in [SmartGit's Settings Directory](../../Installation/Installation-and-Files.md#default-path-of-smartgits-settings-directory).
 
 In rare instances, you may need to edit the `smartgit.properties` file directly.
@@ -32,12 +32,20 @@ The file encoding is `UTF-8`.
 #### Note
 
 >- The `smartgit.properties` file contains only SmartGit-specific settings.
-> To configure the underlying behavior of *Git*, use [**Edit | Preferences | Git Config**](../Preferences/Commands.md#git-config)
-> to change common `git.config` settings. Alternatively, you can edit Git configuration files,
-> such as `.git/config` (for individual Git repository settings) and `~\.gitconfig` (in your HOME directory for global configuration options).
+>  To configure the underlying behavior of *Git*, use [**Edit \| Preferences \| Git Config**](../Preferences/Commands.md#git-config)
+>  to change common `git.config` settings.
+> Alternatively, you can edit Git configuration files, such as `.git/config` (for individual Git repository settings) and `~\.gitconfig` (in your HOME directory for global configuration options).
+
+## Changes View
+
+### changes.maximumFileSize
+
+File comparison can be disabled for very large files, for performance reasons.
+Use this setting to adjust the size (in bytes) at which a file is considered too large for the [**Changes View**](../Changes-View.md). 
+The default value is approximately 1 MB.
 
 #### Note
-> - It is recommended to keep this setting at a reasonable level (a few MB), as setting it too high could negatively impact the performance of the user interface.
+> It is recommended to keep this setting at a reasonable level (a few MB), as setting it too high could negatively impact the performance of the user interface.
 
 ## Networking
 

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/Low-Level-Properties.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/System-Properties
-  - /SmartGit/Manual/System-Properties.html
----
-
 # Changing Low Level Properties in SmartGit
 
 In addition to the options available in the [SmartGit Preferences](../Preferences/index.md), additional customization options are accessible through the SmartGit Properties file (`smartgit.properties`). 

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/Theme-Customization.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/Theme-Customization.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Theme-Customization
-  - /SmartGit/Manual/Theme-Customization.html
----
-
 # Customizing SmartGit's Theme Colors
 
 You can customize certain colors in SmartGit by patching its themes. The custom colors are configured in files `light-patch.theme` and `dark-patch.theme` in [SmartGit's Settings Directory](../../Installation/Installation-and-Files.md#default-path-of-smartgits-settings-directory). Depending on the selected theme from the Preferences, the appropriate file will be used. In case of automatic theme selection (which is the default), your system theme (light or dark) will determine the used file.

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/VM-options.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/VM-options.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/VM-options
-  - /SmartGit/Manual/VM-options.html
----
-
 # Virtual Machine (VM) options
 
 Certain configuration of SmartGit has to be done by *VM options*, in files called `smartgit.vmoptions`. Usually you will want to specify VM options just for your account (current user):

--- a/src/SmartGit/Manual/GUI/AdvancedSettings/index.md
+++ b/src/SmartGit/Manual/GUI/AdvancedSettings/index.md
@@ -1,10 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GUI/AdvancedSettings
-  - /SmartGit/Manual/Advanced-Settings
-  - /SmartGit/Manual/Advanced-Settings.html
----
-
 # Advanced Settings
 
 In addition to the options in the preferences dialog, SmartGit has some advanced settings that can be set through configuration files or through command-line parameters. Both are covered in the following subsections.

--- a/src/SmartGit/Manual/GUI/Bisect.md
+++ b/src/SmartGit/Manual/GUI/Bisect.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Bisect
-  - /SmartGit/Manual/Bisect.html
----
-
 # Bisect
 
 The Bisect command allows you to find out which previous commit introduced problematic behavior in your project's repository, e.g., to find the origin of a bug which was not present in a previous release of an application.

--- a/src/SmartGit/Manual/GUI/Bisect.md
+++ b/src/SmartGit/Manual/GUI/Bisect.md
@@ -4,7 +4,8 @@ The Bisect command allows you to find out which previous commit introduced probl
 
 Bisect works interatively, by checking out a commit approximately mid-way between the current commit (with the bug), and an earlier commit which was known **not** to have contained the bug.
 
-You'll then be required to tell git whether this 'mid point' commit contains the bug (by marking the commit as *bad*), or worked correctly (marking the commit as *good*), e.g. by compiling this version of the application and performing a test. Depending on your response, git will bisect the remaining commits between this midpoint and either the starting commit (if you replied *bad*), or to the current commit (if the midpoint was *good*).
+You'll then be required to tell git whether this 'mid point' commit contains the bug (by marking the commit as *bad*), or worked correctly (marking the commit as *good*), e.g. by compiling this version of the application and performing a test. 
+Depending on your response, git will bisect the remaining commits between this midpoint and either the starting commit (if you replied *bad*), or to the current commit (if the midpoint was *good*).
 
 The process repeats until you narrow down the exact commit which introduced the bug.
 
@@ -14,11 +15,15 @@ In this manner, git bisect will efficiently be able to locate the problematic co
 
 It is recommended that you use bisect in the SmartGit Log or Standard Windows. The Working Tree Window has limited bisect related functionality.
 
-Start a Bisect command by using the menu item **Branch\|Bisect\|Start**. Typically, the current branch HEAD contains the *bad* behavior, so you will usually select **Start Bisect with Bad HEAD**. The HEAD commit show as a red dot, which means *bad*. *Good* commits will be shown as green dots.
+Start a Bisect command by using the menu item **Branch \| Bisect \| Start**. 
+Typically, the current branch HEAD contains the *bad* behavior, so you will usually select **Start Bisect with Bad HEAD**. 
+The HEAD commit show as a red dot, which means *bad*. 
+*Good* commits will be shown as green dots.
 
 Now you will have to find a *good* commit in the commit history that did not contain the issue.
 
-If you are confident that a prior commit (e.g. the inital commit) did not contain the issue, then you can right click on that commit and select `Mark as Good`. If you are unsure, you will need to checkout an earlier commit.
+If you are confident that a prior commit (e.g. the inital commit) did not contain the issue, then you can right click on that commit and select `Mark as Good`. 
+If you are unsure, you will need to checkout an earlier commit.
 
 Now test your application to see whether the issue was present in this commit.
 
@@ -32,6 +37,8 @@ SmartGit will now automatically check out a commit midway between the closest *b
 
 Verify whether your application behaves correctly at this commit, and use the buttons **Mark HEAD as Bad** or **Mark HEAD as Good** as appropriate.
 
-Iterate the above to quickly find the problematic commit that causes the trouble (git bisect will automatically checkout the commits, based on a binary search). Once there are no remaining commits to be tested between a *good* and *bad* commit, SmartGit will show a dialog identifying the commit and author when the issue was introduced into the repository. You can choose to exit by selecting *Leave Bisect*, or you can abort the bisect by clicking **Abort** (in the banner).
+Iterate the above to quickly find the problematic commit that causes the trouble (git bisect will automatically checkout the commits, based on a binary search). 
+Once there are no remaining commits to be tested between a *good* and *bad* commit, SmartGit will show a dialog identifying the commit and author when the issue was introduced into the repository. 
+You can choose to exit by selecting *Leave Bisect*, or you can abort the bisect by clicking **Abort** (in the banner).
 
 Completing or Aborting will check out the branch which was checked out when the Bisect command was first started.

--- a/src/SmartGit/Manual/GUI/Blame.md
+++ b/src/SmartGit/Manual/GUI/Blame.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Blame
-  - /SmartGit/Manual/Blame.html
----
-
 # Blame
 
 SmartGit's Blame window displays the history information for a single file to help you track down the commit in which a certain portion of code was introduced into the repository. You can open the Blame window by selecting a file in the **Files** view and invoking **Query\|Blame** from the top menu, or by clicking the file and selecting **Blame** from the context menu. The Blame window consists of a **Document** view and a **History of current line** view.

--- a/src/SmartGit/Manual/GUI/Blame.md
+++ b/src/SmartGit/Manual/GUI/Blame.md
@@ -1,6 +1,8 @@
 # Blame
 
-SmartGit's Blame window displays the history information for a single file to help you track down the commit in which a certain portion of code was introduced into the repository. You can open the Blame window by selecting a file in the **Files** view and invoking **Query\|Blame** from the top menu, or by clicking the file and selecting **Blame** from the context menu. The Blame window consists of a **Document** view and a **History of current line** view.
+SmartGit's Blame window displays the history information for a single file to help you track down the commit in which a certain portion of code was introduced into the repository. 
+You can open the Blame window by selecting a file in the **Files** view and invoking **Query \| Blame** from the top menu, or by clicking the file and selecting **Blame** from the context menu. 
+The Blame window consists of a **Document** view and a **History of current line** view.
 
 ## Document view
 
@@ -14,7 +16,8 @@ With the top controls, you can:
 
 - Specify the **View Commit** at which the text view will display the file contents. This does not change the currently checked out commit in your Working Tree.
 - Specify how to **Highlight** lines in the text view:
-    - **Changes Since** - The color chosen for a particular line reflects whether the line is 'older' or 'newer' than the specified **Commit** to the right. More precisely, the color reflects whether the date when the line was last modified lies before or after the date of the commit.
+    - **Changes Since** - The color chosen for a particular line reflects whether the line is 'older' or 'newer' than the specified **Commit** to the right. 
+      More precisely, the color reflects whether the date when the line was last modified lies before or after the date of the commit.
     - **Age** - The color chosen for a particular line lies somewhere 'between' the two colors used for the oldest and the newest commit in which the file was modified, and thus reflects the line's relative 'age'.
 
       You can choose between two age criteria for determining the line color, either:
@@ -30,18 +33,23 @@ The *info area* shows the commit metadata in a compact format for each line and 
 - **Date** a compact display of the commit date (e.g. 21d means the commit was added 21 days ago).
 - **Line number** the number of the current line
 
-More detailed information for a specific commit will be displayed in the tooltip, when hovering over the *info area*. Additionally, if the commit message is truncated in the tooltip, the option to expand the full message is available through a keypress Accelerator (e.g. pressing F1). The hyperlinks can be used to navigate to the specific commit.
+More detailed information for a specific commit will be displayed in the tooltip, when hovering over the *info area*. 
+Additionally, if the commit message is truncated in the tooltip, the option to expand the full message is available through a keypress Accelerator (e.g. pressing F1). 
+The hyperlinks can be used to navigate to the specific commit.
 
 ## History view
 
-The **History of current line** view displays the 'history' of the currently selected line from the **Document** view. The 'history' consists of all detected *past* and *future* versions of the line, as it is present in the select **View Commit**. The position of the currently selected line from the **Document** view is denoted by pale borders surrounding the corresponding line in the **History** view.
+The **History of current line** view displays the 'history' of the currently selected line from the **Document** view. 
+The 'history' consists of all detected *past* and *future* versions of the line, as it is present in the select **View Commit**. 
+The position of the currently selected line from the **Document** view is denoted by pale borders surrounding the corresponding line in the **History** view.
 
 The detection of a link between a *past* and a *future* version of a line depends on the changes which have happened in a commit:
 
 - If a number of contiguous lines have been replaced by exactly the same number of lines within a commit, this change will be detected as *modification* of the corresponding lines and they will share the same history.
 - If a number of contiguous lines has been replaced by larger or smaller number of lines, the detection of *matching* lines depends on the outcome of the internal *compare algorithm*.
 - For the case where a line has been detected as *removed* in a commit (instead of *replaced* by another line, which might be more appropriate), the history contains a leading *commit after line has been removed*
-  entry to which you can navigate. For the case where a line has been detected as *added* in a commit (instead of *replacing* another line, what might be more appropriate), the history contains a trailing *commit before line has been added*
+  entry to which you can navigate. 
+- For the case where a line has been detected as *added* in a commit (instead of *replacing* another line, what might be more appropriate), the history contains a trailing *commit before line has been added*
   entry to which you can navigate.
 
 #### Note

--- a/src/SmartGit/Manual/GUI/Branch/Check-Out.md
+++ b/src/SmartGit/Manual/GUI/Branch/Check-Out.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Check-Out
-  - /SmartGit/Manual/Check-Out.html
----
-
 # Using Check Out in SmartGit
 
 The [Git Checkout Command](../../GitConcepts/Branches.md#working-with-branches-using-checkout) is used to switch between branches in a repository.

--- a/src/SmartGit/Manual/GUI/Branch/Cherry-Pick.md
+++ b/src/SmartGit/Manual/GUI/Branch/Cherry-Pick.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Cherry-Pick
-  - /SmartGit/Manual/Cherry-Pick.html
----
-
 # Cherry-Picking in SmartGit
 
 Cherry Picking allows you to apply one or more (arbitrary) commits from other branches into the current branch in the Working Tree. Please refer to the section on **[Cherry-Picking](../../GitConcepts/Cherry-Picking.md)** for an overview.

--- a/src/SmartGit/Manual/GUI/Branch/Conflict-Solver.md
+++ b/src/SmartGit/Manual/GUI/Branch/Conflict-Solver.md
@@ -4,7 +4,7 @@ SmartGit comes with a Conflict Solver tool that allows merge conflict resolution
 
 For details on how Git manages merge conflicts, and the meaning of `ours`, `theirs`, `common`, and `base` files, refer to the [Git manual](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
 
-SmartGit's Conflict Solver view is invoked from the **Query | Conflict Solver** command, and consists of the following elements:
+SmartGit's Conflict Solver view is invoked from the **Query \| Conflict Solver** command, and consists of the following elements:
 
 - The **left pane** shows the local branch commit version of the file (`ours`, also referred to as `:2` in git)
 - The **center pane** shows the file's current conflicted Working Tree version, including the merge conflict markers.  
@@ -31,4 +31,4 @@ The following commands are available in the SmartGit conflict resolver (commands
 - **Merge Below:** Moves the `Working Tree` pane to the bottom. This is useful for merging files with long lines.
 - **Close:** Closes the Conflict Solver. You will be prompted to do so if you haven't saved changes. The Conflict Solver will warn you if unresolved conflicts remain in the Working Tree file.
 
-You can substitute the SmartGit Conflict Solver with another standalone tool if you prefer another three-way merge tool to resolve conflicts. Please refer to [Preferences | Tools](../../Preferences/Tools.md#conflict-solvers) for instructions on how to do this.
+You can substitute the SmartGit Conflict Solver with another standalone tool if you prefer another three-way merge tool to resolve conflicts. Please refer to [Preferences \| Tools](../../Preferences/Tools.md#conflict-solvers) for instructions on how to do this.

--- a/src/SmartGit/Manual/GUI/Branch/Manipulating-branches-tags.md
+++ b/src/SmartGit/Manual/GUI/Branch/Manipulating-branches-tags.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Manipulating-branches-tags
-  - /SmartGit/Manual/Manipulating-branches-tags.html
----
-
 # Manipulating Branches and Tags
 
 In Git, Branches and Tags provide human-readable pointers / references to specific commits in a repository. The key differentiation is that *Tags* will remain pointed to a specific commit, whereas *Branches* will move to point to the most recent HEAD commit when a new commit is added to a branch.

--- a/src/SmartGit/Manual/GUI/Branch/Merge.md
+++ b/src/SmartGit/Manual/GUI/Branch/Merge.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Merge
-  - /SmartGit/Manual/Merge.html
----
-
 # Merging in SmartGit
 
 For an overview of general merging techniques in Git, please refer to *[Merge](../../GitConcepts/Merging.md)*.

--- a/src/SmartGit/Manual/GUI/Branch/Rebase-Interactive.md
+++ b/src/SmartGit/Manual/GUI/Branch/Rebase-Interactive.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Rebase-Interactive
-  - /SmartGit/Manual/Rebase-Interactive.html
----
-
 # Interactive Rebasing in SmartGit
 
 As the name suggests, Interactive Rebasing (`git rebase -i`) allows fine-level control over what should happen with each commit.

--- a/src/SmartGit/Manual/GUI/Branch/Rebase.md
+++ b/src/SmartGit/Manual/GUI/Branch/Rebase.md
@@ -4,7 +4,7 @@
 
 In SmartGit, there are several ways to initiate a rebase:
 
-- **Menu and toolbar:** On the Working tree window, select **Branch\|Rebase** to open the **Rebase** dialog, where you can select the branch to rebase the HEAD onto, or the branch to rebase onto the HEAD, respectively.
+- **Menu and toolbar:** On the Working tree window, select **Branch \| Rebase** to open the **Rebase** dialog, where you can select the branch to rebase the HEAD onto, or the branch to rebase onto the HEAD, respectively.
 
 You can open this dialog using the **Rebase** toolbar button, depending on your toolbar settings.
 

--- a/src/SmartGit/Manual/GUI/Branch/Rebase.md
+++ b/src/SmartGit/Manual/GUI/Branch/Rebase.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Rebase
-  - /SmartGit/Manual/Rebase.html
----
-
 # Rebasing in SmartGit
 
 [Rebasing](../../GitConcepts/Rebasing.md) is a powerful feature of Git which allows the commit history of branches and commits in a repository to be rearranged.

--- a/src/SmartGit/Manual/GUI/Branch/Revert.md
+++ b/src/SmartGit/Manual/GUI/Branch/Revert.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Revert
-  - /SmartGit/Manual/Revert.html
----
-
 # Reverting Commits in SmartGit
 
 The [`git revert`](../../GitConcepts/Reverting.md) command allows you to 'undo' the effects of unwanted commits in the current branch by creating a new commit that represents the work needed to reverse the changes from previous commits.

--- a/src/SmartGit/Manual/GUI/Branch/index.md
+++ b/src/SmartGit/Manual/GUI/Branch/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GUI/Branch
----
 # Working with Branches in SmartGit
 
 Branches are an essential part of git, allowing you to conceptually track and manage changes to your repository. SmartGit's UI exposes all common branch actions intuitively through views on the user interface.

--- a/src/SmartGit/Manual/GUI/Branches-view.md
+++ b/src/SmartGit/Manual/GUI/Branches-view.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Branches-view
-  - /SmartGit/Manual/Branches-view.html
----
-
 # Branches view
 
 The **Branches** view shows *local* and *remote* branches, tags, and other *refs* from your repository and offers operations on these

--- a/src/SmartGit/Manual/GUI/Branches-view.md
+++ b/src/SmartGit/Manual/GUI/Branches-view.md
@@ -19,4 +19,4 @@ If "Recyclable Commits" is selected, all commits not reachable by refs are shown
 
 ## Tag-Grouping
 
-The **Tags**-part of the **Branches** view will be grouped according to a *tag-grouping configuration*. This configuration is stored in your repository's `.git/config` and can be edited in **Repository\|Settings**, under the [**Tag-Grouping**](Repository/Repository-Settings.md#tag-grouping) section. To disable this grouping feature for the current repository, set both **Pattern** fields empty.
+The **Tags**-part of the **Branches** view will be grouped according to a *tag-grouping configuration*. This configuration is stored in your repository's `.git/config` and can be edited in **Repository \| Settings**, under the [**Tag-Grouping**](Repository/Repository-Settings.md#tag-grouping) section. To disable this grouping feature for the current repository, set both **Pattern** fields empty.

--- a/src/SmartGit/Manual/GUI/Bug-Reports.md
+++ b/src/SmartGit/Manual/GUI/Bug-Reports.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Bug-Reports
-  - /SmartGit/Manual/Bug-Reports.html
----
-
 # Bug Reports
 
 ## Detailed Bug Reports

--- a/src/SmartGit/Manual/GUI/Bugtraq-links-to-issue-trackers-.md
+++ b/src/SmartGit/Manual/GUI/Bugtraq-links-to-issue-trackers-.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Bugtraq-links-to-issue-trackers-
-  - /SmartGit/Manual/Bugtraq-links-to-issue-trackers-.html
----
-
 # Bugtraq (links to issue trackers)
 
 Git Bugtraq is a [de-facto standard](https://github.com/mstrap/bugtraq) configuration file added into your Git Repository, enabling integration between tools such as SmartGit and common Bug Tracking tools such as JIRA or GitHub issues.

--- a/src/SmartGit/Manual/GUI/Changes-View.md
+++ b/src/SmartGit/Manual/GUI/Changes-View.md
@@ -14,8 +14,10 @@ Use the `<<` and `>>` arrow buttons to move changed *Hunks* between panes, or us
 > - You can't move staged changes directly into **HEAD**, as that will require a new commit.
 > - The **Changes View** has only 2 panes, and as a result, the **HEAD** (repository) file version does NOT appear in the **Changes View** unless the file has been staged.
 >   To view the 3 panes at once, please use the [**Index Editor**](Stage-Unstage-IndexEditor.md#the-index-editor).
-> - **Changes View** won't automatically compare files larger than the configured *maximum file size* setting.
->   The value can be changed in the [*Low Level Properties* preferences](AdvancedSettings/Low-Level-Properties.md#changesmaximumfilesize)
+> - **Changes View** won't automatically compare files larger than the configured `changes.maximumFileSize` low-level setting.
+>   If you attempt to compare a file larger than this setting, SmartGit will warn that the *'File size exceeds the configured limit'*.
+>   Clicking **Force Compare** will override the limit temporarily for this file, and perform the comparison.
+>   The value can be changed more permanently in the [*Low Level Properties* preferences](AdvancedSettings/Low-Level-Properties.md#changesmaximumfilesize).
 
 There are several options to customize the layout of the **Changes View**:
 - Select between *Unified* and *Side by Side* mode to view the Index and Working Tree versions either as separate panes, or as a unified change.

--- a/src/SmartGit/Manual/GUI/Command-Line-Options.md
+++ b/src/SmartGit/Manual/GUI/Command-Line-Options.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Command-Line-Options
-  - /SmartGit/Manual/Command-Line-Options.html
----
-
 # Command-Line Options
 
 This section gives an overview of the various command-line options which can be passed as parameters to the SmartGit launcher at start-up. The launcher used by SmartGit depends on your platform:

--- a/src/SmartGit/Manual/GUI/Ignore-Skip-AssumeUnchanged.md
+++ b/src/SmartGit/Manual/GUI/Ignore-Skip-AssumeUnchanged.md
@@ -17,7 +17,7 @@ such as entire folders, and files matching wild card patterns to be ignored.
 
 #### Tip
 
-> To view a list of ignored files or to understand why a specific file is *ignored*, use **Local\|Edit Ignore File**.
+> To view a list of ignored files or to understand why a specific file is *ignored*, use **Local \| Edit Ignore File**.
 
 ## Assume Unchanged
 

--- a/src/SmartGit/Manual/GUI/Journal-View.md
+++ b/src/SmartGit/Manual/GUI/Journal-View.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Journal-View
-  - /SmartGit/Manual/Journal-View.html
----
-
 # Journal View
 
 The Journal View in SmartGit shows a compact history for the current branch, in linear fashion. This differs from the [Log view](Log.md) in that only the commits in the current branch are displayed.

--- a/src/SmartGit/Manual/GUI/Journal-View.md
+++ b/src/SmartGit/Manual/GUI/Journal-View.md
@@ -31,5 +31,5 @@ See [Interactive Rebase](Branch/Rebase-Interactive.md) for details on how to cha
 
 >
 >To just change the commit message of the last commit (even for a merge commit or if the working copy is not clean),
-> invoke **Local\|Edit Last Commit Message**.
+> invoke **Local \| Edit Last Commit Message**.
 >

--- a/src/SmartGit/Manual/GUI/Local-Operations-on-the-Working-Tree.md
+++ b/src/SmartGit/Manual/GUI/Local-Operations-on-the-Working-Tree.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Local-Operations-on-the-Working-Tree
-  - /SmartGit/Manual/Local-Operations-on-the-Working-Tree.html
----
-
 # Local Operations on the Working Tree
 
 After making changes in the Working Tree, the next step is to prepare a new commit by identifying which changes you want to include in the commit.

--- a/src/SmartGit/Manual/GUI/Log.md
+++ b/src/SmartGit/Manual/GUI/Log.md
@@ -2,7 +2,7 @@
 
 The SmartGit Log display provides interactive visualization of the Git Log, allowing you to view the structure of the commit history in a repository, and to visualize the changes made to files and directories as commits are added.
 
-Log is invoked from the **Query\|Log** menu option.
+Log is invoked from the **Query \| Log** menu option.
 
 #### Tip
 

--- a/src/SmartGit/Manual/GUI/Log.md
+++ b/src/SmartGit/Manual/GUI/Log.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Log
-  - /SmartGit/Manual/Log.html
----
-
 # Git Log
 
 The SmartGit Log display provides interactive visualization of the Git Log, allowing you to view the structure of the commit history in a repository, and to visualize the changes made to files and directories as commits are added.

--- a/src/SmartGit/Manual/GUI/Main-Windows.md
+++ b/src/SmartGit/Manual/GUI/Main-Windows.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Main-Windows
-  - /SmartGit/Manual/Main-Windows.html
----
-
 # Main Windows
 
 SmartGit provides three different Main Windows, all of which can execute Git commands, but each is tailored to a different type of git usage.

--- a/src/SmartGit/Manual/GUI/Preferences/Commands.md
+++ b/src/SmartGit/Manual/GUI/Preferences/Commands.md
@@ -133,7 +133,7 @@ This tab-set allows you to edit your `.gitconfig` file, which controls a number 
 
 #### Note
 
-> Advanced Users can also edit the Global and Repository-specific git configuration files directly using the **Repository\|Edit Git Config** menu Option
+> Advanced Users can also edit the Global and Repository-specific git configuration files directly using the **Repository \| Edit Git Config** menu Option
 > and then select the **User** or **Repository** option respectively.
 
 

--- a/src/SmartGit/Manual/GUI/Preferences/Tools.md
+++ b/src/SmartGit/Manual/GUI/Preferences/Tools.md
@@ -141,7 +141,7 @@ By default, the list of tools is searched from top to bottom and the first match
 
 ## Conflict Solvers
 
-SmartGit comes with a built-in conflict solver (three-way-merge) which will be used by default when invoking **Query\|Conflict Solver**. If you prefer, you can configure external three-way-merge tools which should be used instead. The following **Arguments** can be passed to the configured **External Conflict Solver**:
+SmartGit comes with a built-in conflict solver (three-way-merge) which will be used by default when invoking **Query \| Conflict Solver**. If you prefer, you can configure external three-way-merge tools which should be used instead. The following **Arguments** can be passed to the configured **External Conflict Solver**:
 
 - `${mergeFile}` represents the resulting conflicting file, as-is in the working tree
 - `${leftFile}` represents Git's "ours" version of the file (:2)

--- a/src/SmartGit/Manual/GUI/Preferences/Tools.md
+++ b/src/SmartGit/Manual/GUI/Preferences/Tools.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Tools
-  - /SmartGit/Manual/Tools.html
----
-
 # Tools
 
 The **Tools** preferences settings allow you to define external tools to assist you when using SmartGit:

--- a/src/SmartGit/Manual/GUI/Preferences/index.md
+++ b/src/SmartGit/Manual/GUI/Preferences/index.md
@@ -1,10 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GUI/Preferences
-  - /SmartGit/Manual/Preferences
-  - /SmartGit/Manual/Preferences.html
----
-
 # Preferences
 
 The preferences dialog in SmartGit (**Edit \| Preferences**) allows you to customize SmartGit to suit your workflow and personal preferences. This will open a dialog where you can adjust settings such as user-interface options, additional tools, proxy settings and keyboard shortcuts.

--- a/src/SmartGit/Manual/GUI/Repository/Clone.md
+++ b/src/SmartGit/Manual/GUI/Repository/Clone.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Clone
-  - /SmartGit/Manual/Clone.html
----
-
 # Cloning Repositories
 
 Use the **Repository \| Clone** option to create a clone of an existing Git repository.

--- a/src/SmartGit/Manual/GUI/Repository/Managing-Remotes.md
+++ b/src/SmartGit/Manual/GUI/Repository/Managing-Remotes.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Managing-Remotes
-  - /SmartGit/Manual/Managing-Remotes.html
----
-
 # Managing Remotes
 
 Frequently, developers may [Clone](Clone.md) a remote repository, and will always pull or push new commits and branches in your local repository only to this remote (with a default name of *origin*).

--- a/src/SmartGit/Manual/GUI/Repository/Repositories-Directories-and-Files.md
+++ b/src/SmartGit/Manual/GUI/Repository/Repositories-Directories-and-Files.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Repositories-Directories-and-Files
-  - /SmartGit/Manual/Repositories-Directories-and-Files.html
----
-
 # Repositories, Directories and Files
 
 The *Repositories view* shows all local repositories known to SmartGit in a tree structure. Repositories which are opened by SmartGit will appear in **Bold** in this window, and the directory structure, and states of folders in the repository Working Tree will appear nested underneath each opened repository.

--- a/src/SmartGit/Manual/GUI/Repository/Repository-Settings.md
+++ b/src/SmartGit/Manual/GUI/Repository/Repository-Settings.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Repository-Settings
-  - /SmartGit/Manual/Repository-Settings.html
----
-
 # Repository Settings
 
 After selecting a Repository, you can use the **Repository \| Settings** menu command or the Settings context menu on the highlighted repository. This opens a dialog to configure certain options of your repository (`<repository>/.git/config`) file.

--- a/src/SmartGit/Manual/GUI/Repository/Submodules.md
+++ b/src/SmartGit/Manual/GUI/Repository/Submodules.md
@@ -15,36 +15,42 @@ Submodules offer a way to link one or embedded repositories into a parent reposi
 
 A submodule usually shows up in SmartGit's UI at the same time in the [*Repositories View*](../Repositories-View.md) and in the **Files** view. Available Operations on the main menu will depend on whether the **Repositories** view or the **Files** is in focus:
 
-- The **Repositories** view offers operations in the submodule repository itself: e.g. you can invoke a **Log** here to see the history of the submodule repository or you can invoke **Remote\|Submodule\|Initialize** to initialize all sub-submodules contained in the selected submodule.
+- The **Repositories** view offers operations in the submodule repository itself: 
+  e.g. you can invoke a **Log** here to see the history of the submodule repository or you can invoke **Remote \| Submodule \| Initialize** to initialize all sub-submodules contained in the selected submodule.
 - The **Files** view offers operations on the submodule pointer from perspective of the parent repository: e.g. you can invoke a **Log**
-  here to see how the submodule-pointer has changed over time or you can invoke **Remote\|Submodule\|Initialize** to initialize the selected submodule itself (if it is not yet initialized).
+  here to see how the submodule-pointer has changed over time or you can invoke **Remote \| Submodule \| Initialize** to initialize the selected submodule itself (if it is not yet initialized).
 
 ## Cloning Repositories with Submodules
 
-If you clone an existing repository containing one or more submodules via **Repository\|Clone**, make sure the option **Include Submodules**
-is selected, so that all first-level submodules are automatically initialized and updated. Without this option, you may initialize the submodules later by hand via **Remote\|Submodule\|Initialize**. Only performing the initialization will leave the submodule directory empty. For a fully functional submodule, you'll also need to do a pull on it, as described in [Updating Submodules](#updating-submodules).
+If you clone an existing repository containing one or more submodules via **Repository \| Clone**, make sure the option **Include Submodules**
+is selected, so that all first-level submodules are automatically initialized and updated. 
+Without this option, you may initialize the submodules later by hand via **Remote \| Submodule \| Initialize**. 
+Only performing the initialization will leave the submodule directory empty. 
+For a fully functional submodule, you'll also need to do a pull on it, as described in [Updating Submodules](#updating-submodules).
 
 ## Adding, Removing and Synchronizing Submodules
 
 #### Note
-
 >
 >Submodules will show up in the **Repositories** view, as well as the **Files** view.
 > Submodule operations (from the parent repository perspective) will be performed in the **Files** view.
 > 'Normal' Git operations on the submodule repository itself will be performed in the **Repositories** view.
 >
 
-To "ignore" a not-yet initialized submodule which you are not interested in, invoke **Remote\|Submodule\|Deactivate**. This will hide the submodule from the **Files** view, unless **View\|Show Ignored Files** is selected.
+To "ignore" a not-yet initialized submodule which you are not interested in, invoke **Remote \| Submodule \| Deactivate**. 
+This will hide the submodule from the **Files** view, unless **View\|Show Ignored Files** is selected.
 (Technically, SmartGit will set `submodule.<name>.active=false` in the parent repository `.git/config`.)
 
-To remove a submodule from the working tree, select the submodule in the **Files** view, invoke **Remote\|Submodule\|Deinit**. After *deiniting* you will probably want to **Deactivate** it, too.
+To remove a submodule from the working tree, select the submodule in the **Files** view, invoke **Remote \| Submodule \| Deinit**. 
+After *deiniting* you will probably want to **Deactivate** it, too.
 
-To add a new submodule to a repository, invoke **Remote\|Submodule\|Add** on the repository in the **Repositories**
+To add a new submodule to a repository, invoke **Remote \| Submodule \| Add** on the repository in the **Repositories**
 view and follow the dialog instructions.
 
-To remove a submodule from the repository, select the submodule in the **Files** view, invoke **Remote\|Submodule\|Unregister**, and then commit your changes. After the submodule is unregistered, you may delete the entire submodule directory.
+To remove a submodule from the repository, select the submodule in the **Files** view, invoke **Remote \| Submodule \| Unregister**, and then commit your changes. 
+After the submodule is unregistered, you may delete the entire submodule directory.
 
-If the URL of a submodule's remote repository has changed, you need to modify the URL in the `.gitmodules` file and then *synchronize* the submodule, via **Remote\|Submodule\|Synchronize**, so that the new URL is written into Git's configuration.
+If the URL of a submodule's remote repository has changed, you need to modify the URL in the `.gitmodules` file and then *synchronize* the submodule, via **Remote \| Submodule \| Synchronize**, so that the new URL is written into Git's configuration.
 
 ## Updating Submodules
 
@@ -53,11 +59,15 @@ After a submodule has been set up, the usual workflow is that some files in the 
 
 ### Pulling on the Submodule
 
-Select the submodule in the **Repositories** view and invoke **Remote\|Pull**. After the pull, the submodule will have a different appearance in the **Repositories** view if new commits have been fetched and a rebase or merge has been performed. This different appearance indicates that the submodule has changed and that you need to [commit](../Local-Operations-on-the-Working-Tree.md#commit) the change in the outer repository.
+Select the submodule in the **Repositories** view and invoke **Remote \| Pull**. After the pull, the submodule will have a different appearance in the **Repositories** view if new commits have been fetched and a rebase or merge has been performed. This different appearance indicates that the submodule has changed and that you need to [commit](../Local-Operations-on-the-Working-Tree.md#commit) the change in the outer repository.
 
 ### Pulling on the Outer Repository
 
-Open the repository settings via **Repository\|Settings**, and in the **Pull** section, enable **Update registered submodules**, so that SmartGit automatically updates all registered submodules when pulling on the outer repository. Additionally, you may also enable **And initialize new submodules**; with this, SmartGit will update not only registered submodules when pulling, but also uninitialized submodules, after having initialized them. The aforementioned **Update** option will only fetch commits as needed, i.e. when a commit is referenced by the outer repository as the current state of the submodule. If you want to fetch all new commits instead, enable the option **Always fetch new commits, tags and branches from submodule**. Note that when you do a pull on the outer repository, you need to pull with subsequent rebase or merge, otherwise new submodule commits will only be fetched, without changing the submodule state (i.e. the commit the submodule is currently pointing at).
+Open the repository settings via **Repository \| Settings**, and in the **Pull** section, enable **Update registered submodules**, so that SmartGit automatically updates all registered submodules when pulling on the outer repository. 
+Additionally, you may also enable **And initialize new submodules**; with this, SmartGit will update not only registered submodules when pulling, but also uninitialized submodules, after having initialized them. 
+The aforementioned **Update** option will only fetch commits as needed, i.e. when a commit is referenced by the outer repository as the current state of the submodule. 
+If you want to fetch all new commits instead, enable the option **Always fetch new commits, tags and branches from submodule**. 
+Note that when you do a pull on the outer repository, you need to pull with subsequent rebase or merge, otherwise new submodule commits will only be fetched, without changing the submodule state (i.e. the commit the submodule is currently pointing at).
 
 ## Working within Submodules
 

--- a/src/SmartGit/Manual/GUI/Repository/Submodules.md
+++ b/src/SmartGit/Manual/GUI/Repository/Submodules.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Submodules
-  - /SmartGit/Manual/Submodules.html
----
-
 # Submodules in SmartGit
 
 Submodules offer a way to link one or embedded repositories into a parent repository. Please refer to [Submodule Concepts](../../GitConcepts/Submodules.md) for background information.

--- a/src/SmartGit/Manual/GUI/Repository/Subtrees.md
+++ b/src/SmartGit/Manual/GUI/Repository/Subtrees.md
@@ -9,20 +9,20 @@ category. The root commits of a subtree will be denoted by a *folder*-symbol in 
 
 ## Basic Subtree operations
 
-To add a new subtree, select the root directory of the repository in the **Repositories** view and invoke **Remote\|Subtree\|Add**.
+To add a new subtree, select the root directory of the repository in the **Repositories** view and invoke **Remote \| Subtree \| Add**.
 
-To fetch new (remote) changes from the subtree repository, select the subtree remote in the **Branches** view and invoke **Pull** from the context menu. Alternatively, you can invoke **Remote\|Pull** from the main menu and for **Fetch From** select the subtree remote there.
+To fetch new (remote) changes from the subtree repository, select the subtree remote in the **Branches** view and invoke **Pull** from the context menu. Alternatively, you can invoke **Remote \| Pull** from the main menu and for **Fetch From** select the subtree remote there.
 
 To merge, or cherry-pick, a subtree use the **Merge** or **Cherry-Pick** command. SmartGit will understand whether the source commit is a subtree and in this case perform a subtree merge / cherry-pick as applicable.
 
-To push commits back to a subtree, select the (remote) subtree branch in the **Branches** view and invoke **Remote\|Subtree\|Push**. Pushing a subtree involves splitting changes back from main repository to subtree repository (more details can be found below).
+To push commits back to a subtree, select the (remote) subtree branch in the **Branches** view and invoke **Remote \| Subtree \| Push**. Pushing a subtree involves splitting changes back from main repository to subtree repository (more details can be found below).
 
-To reset your main repository to a certain subtree commit or branch, first **Check Out** the branch which should be reset. Then, in the **Branches** view, select the subtree branch to which your main repository should be reset to and invoke **Subtree\|Reset** from the context menu.
+To reset your main repository to a certain subtree commit or branch, first **Check Out** the branch which should be reset. Then, in the **Branches** view, select the subtree branch to which your main repository should be reset to and invoke **Subtree \| Reset** from the context menu.
 
 #### Note
 
 > If there are already existing subtrees in your main repository you will
-> have to add corresponding remotes for these subtrees using **Remote\|Add**.
+> have to add corresponding remotes for these subtrees using **Remote \| Add**.
 
 ## Synchronizing changes back to the subtree repository
 
@@ -30,7 +30,7 @@ After having applied changes to files in your main repository which actually bel
 
 1. **Check Out** the main repository's branch which should be split back.
 
-2. In the **Branches** view, select the subtree branch to which the changes should be split back and invoke **Subtree\|Split** from the context menu. The commits created by the *Split*-command will be written to the **Subtree-Branch to update**. If you have selected a remote subtree branch, you will have to select **Subtree-Branch to update** or enter the name of a new branch there; in either case the selected branch will then be updated/created.
+2. In the **Branches** view, select the subtree branch to which the changes should be split back and invoke **Subtree \| Split** from the context menu. The commits created by the *Split*-command will be written to the **Subtree-Branch to update**. If you have selected a remote subtree branch, you will have to select **Subtree-Branch to update** or enter the name of a new branch there; in either case the selected branch will then be updated/created.
 
 	#### Note
 	> SmartGit will not actually split changes back to this

--- a/src/SmartGit/Manual/GUI/Repository/Subtrees.md
+++ b/src/SmartGit/Manual/GUI/Repository/Subtrees.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Subtrees
-  - /SmartGit/Manual/Subtrees.html
----
-
 # Subtrees
 
 Subtrees allow to integrate contents from other repositories into sub-folders of your main repository. They are an alternative to [Submodules](Submodules.md).

--- a/src/SmartGit/Manual/GUI/Repository/Synchronizing-with-Remote-Repositories.md
+++ b/src/SmartGit/Manual/GUI/Repository/Synchronizing-with-Remote-Repositories.md
@@ -6,7 +6,7 @@ Synchronizing the states of local and remote repositories involves *Pull*ing fro
 
 The Pull command fetches commits from a remote repository, stores them in the remote branches, and optionally 'integrates' these commits (i.e. by fast-forwarding, or by adding merge or rebase commits) into the local branch, depending on the nature of divergence of the branches, and the [configured preference](Repository-Settings.md#fetch-and-pull) for merge types.
 
-Use **Remote\|Pull** (or the corresponding toolbar button) to invoke the Pull command.
+Use **Remote \| Pull** (or the corresponding toolbar button) to invoke the Pull command.
 
 This will open the Pull dialog, where you can specify what SmartGit will do after the commits have been fetched:
 
@@ -14,7 +14,7 @@ This will open the Pull dialog, where you can specify what SmartGit will do afte
 - You can click **More Options** to customize the Pull (Note: These are only relevant if you select **Pull**. The options below are ignored with **Fetch Only**):
     - If a fast-forward is not possible, you have the choice whether to [Merge](../Branch/Merge.md) the local commits with the fetched commits, or [Rebase](../Branch/Rebase.md) the local commits onto the fetched commits.
     - **Update existing and fetch new tags** will also integrate any tag changes detected in the remote. By default, Git (and hence SmartGit) will only pull new tags, but won't update any changed tags in the remote repository.
-    - **Remember as default for repository** will update the **Repository\|Settings** with the above new preferences. Additional options are available when working with the remote, which can be configured in the [Repository Settings](Repository-Settings.md).
+    - **Remember as default for repository** will update the **Repository \| Settings** with the above new preferences. Additional options are available when working with the remote, which can be configured in the [Repository Settings](Repository-Settings.md).
 
 The Pull Dialog has 3 buttons:
 
@@ -52,9 +52,9 @@ If you try to push commits from a new local branch, you will be asked whether to
 
 The Push commands listed above can be invoked from several places:
 
-- **Menu and toolbar** In the menu, you can invoke the various Pull, and Push commands with **Remote\|Pull**, **Remote\|Push**, **Remote\|Push To** and **Remote\|Push Commits**.
-  **Remote\|Push** and **Remote\|Push To** may also be available as toolbar buttons, depending on your toolbar configuration.
-  **Remote\|Push Commits** is only enabled if the **Journal** view is focused.
+- **Menu and toolbar** In the menu, you can invoke the various Pull, and Push commands with **Remote \| Pull**, **Remote \| Push**, **Remote \| Push To** and **Remote \| Push Commits**.
+  **Remote \| Push** and **Remote \| Push To** may also be available as toolbar buttons, depending on your toolbar configuration.
+  **Remote \| Push Commits** is only enabled if the **Journal** view is focused.
 - **Repositories view** You can invoke **Push** in the **Repositories** view by selecting the open repository and choosing
   **Push** from the context menu.
 - **Branches view** In the context menu of the **Branches** view, you can invoke **Push** and **Push To** on local branches. Additionally, you can invoke **Push** on tags.
@@ -103,7 +103,7 @@ With the Synchronize command, you can push local commits to a remote repository 
 
 The Synchronize command can be invoked as follows:
 
-- from the menu via **Remote\|Synchronize**,
+- from the menu via **Remote \| Synchronize**,
 - with the Synchronize toolbar button,
 - and in the **Repositories** view via **Synchronize** in the repository's context menu.
 

--- a/src/SmartGit/Manual/GUI/Repository/Synchronizing-with-Remote-Repositories.md
+++ b/src/SmartGit/Manual/GUI/Repository/Synchronizing-with-Remote-Repositories.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Synchronizing-with-Remote-Repositories
-  - /SmartGit/Manual/Synchronizing-with-Remote-Repositories.html
----
-
 # Synchronizing with Remote Repositories
 
 Synchronizing the states of local and remote repositories involves *Pull*ing from, and *Push*ing to, a remote repository(ies). SmartGit also has a *Synchronize* command that combines pulling and pushing.

--- a/src/SmartGit/Manual/GUI/Repository/index.md
+++ b/src/SmartGit/Manual/GUI/Repository/index.md
@@ -1,10 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GUI/Repository
-  - /SmartGit/Manual/Repository-Related
-  - /SmartGit/Manual/Repository-Related.html
----
-
 # Working with Repositories
 
 This section describes common SmartGit actions you'll need to use when working with Git Repositories on your local system.

--- a/src/SmartGit/Manual/GUI/Tips-and-Tricks.md
+++ b/src/SmartGit/Manual/GUI/Tips-and-Tricks.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Tips-and-Tricks
-  - /SmartGit/Manual/Tips-and-Tricks.html
----
-
 # Tips and Tricks
 
 Once you have mastered the basics of using SmartGit to work with git repositories, these handy tips will help you improve productivity within SmartGit. Additionally, please go through our list of [How-To articles](../../HowTos/index.md) to get the most out of SmartGit.

--- a/src/SmartGit/Manual/GUI/Tips-and-Tricks.md
+++ b/src/SmartGit/Manual/GUI/Tips-and-Tricks.md
@@ -12,13 +12,14 @@ Feel free to cast your vote to [this Eclipse issue](https://bugs.eclipse.org/bug
 
 In input fields for files and directories when typing the file path, you will get completion hints after a (back) slash. On Unix-like systems you can use `~/` to complete content in the home directory.
 
-For the input field to add or edit the path of a Git remote (**Remote\|Add** and **Remote\|Edit URL**) you can use `../` to complete relative paths in case you've cloned a repository parallel to another.
+For the input field to add or edit the path of a Git remote (**Remote \| Add** and **Remote \| Edit URL**) you can use `../` to complete relative paths in case you've cloned a repository parallel to another.
 
 To complete file names in the **Commit Message** input field of the **Commit** dialog, use *\<Ctrl>+\<Space>*-keystroke.
 
 ## Text Editors
 
-To select words or larger parts of text, you can press *\<Ctrl>+\<W>*-keystroke multiple times until you have expanded the selection as desired. To copy or cut the whole line to the clipboard, set the caret inside the line without selecting anything and press the *\<Ctrl/Cmd>+\<C>*-keystroke or the *\<Ctrl/Cmd>+\<X>*-keystroke.
+To select words or larger parts of text, you can press *\<Ctrl>+\<W>*-keystroke multiple times until you have expanded the selection as desired. 
+To copy or cut the whole line to the clipboard, set the caret inside the line without selecting anything and press the *\<Ctrl/Cmd>+\<C>*-keystroke or the *\<Ctrl/Cmd>+\<X>*-keystroke.
 
 ## Compare
 

--- a/src/SmartGit/Manual/GUI/index.md
+++ b/src/SmartGit/Manual/GUI/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GUI
----
 # SmartGit User Interface Reference
 
 This article aims to provide a starting point for using the SmartGit application.

--- a/src/SmartGit/Manual/GitConcepts/Branches.md
+++ b/src/SmartGit/Manual/GitConcepts/Branches.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Branches
-  - /SmartGit/Manual/Branches.html
----
-
 # Branches
 
 Git uses branches to store an independent series of commits within a repository.

--- a/src/SmartGit/Manual/GitConcepts/Commits.md
+++ b/src/SmartGit/Manual/GitConcepts/Commits.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Commits
-  - /SmartGit/Manual/Commits.html
----
-
 # Commits
 
 A *commit* is a set of file changes stored in a repository along with a commit message. The **[Commit command](../GUI/Local-Operations-on-the-Working-Tree.md#commit)** is used to store working tree changes (which have been staged) in the local repository, thereby creating a new commit.

--- a/src/SmartGit/Manual/GitConcepts/The-Index.md
+++ b/src/SmartGit/Manual/GitConcepts/The-Index.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/The-Index
-  - /SmartGit/Manual/The-Index.html
----
-
 # The Index
 
 The *Index* is an intermediate cache for preparing a commit by identifying which file changes (including new and deleted files) you'd like to include in your next commit.

--- a/src/SmartGit/Manual/GitConcepts/Working-Tree-States.md
+++ b/src/SmartGit/Manual/GitConcepts/Working-Tree-States.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Working-Tree-States
-  - /SmartGit/Manual/Working-Tree-States.html
----
-
 # Working Tree States
 
 The Working Tree is the folder structure into which files in your repository will be placed after a check out.

--- a/src/SmartGit/Manual/GitConcepts/index.md
+++ b/src/SmartGit/Manual/GitConcepts/index.md
@@ -1,10 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GitConcepts
-  - /SmartGit/Manual/Git-Concepts
-  - /SmartGit/Manual/Git-Concepts.html
----
-
 # Git Concepts
 
 This section aims to help you get started with Git and gives you an understanding of the fundamental concepts of the Git version control system.

--- a/src/SmartGit/Manual/Installation/Company-wide-installation.md
+++ b/src/SmartGit/Manual/Installation/Company-wide-installation.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Company-wide-installation.html
-  - /SmartGit/Manual/Company-wide-installation
----
-
 # Company-wide installation
 
 For company-wide installations, the administrator may install SmartGit on a read-only location or network share or customize the installation process by e.g. using batch files. To set up a custom initial configuration for the users, certain settings files can be prepared and put into a directory named `default`. For MacOS this `default` directory must be located in `SmartGit.app/Contents/Resources/` (parallel to the `Java` directory). For other operating systems, the `default` directory must be located within SmartGit's installation directory, and parallel to the `lib` and `bin` directories.

--- a/src/SmartGit/Manual/Installation/Installation-and-Files.md
+++ b/src/SmartGit/Manual/Installation/Installation-and-Files.md
@@ -46,17 +46,20 @@ Below are the locations of SmartGit's settings files, depending on the OS:
 To reset certain parts of SmartGit's configuration ("settings") back to installation defaults:
 
 1. Locate the appropriate configuration file (`*.yml`)
-2. Exit SmartGit, using **Repository\|Exit**
+2. Exit SmartGit, using **Repository \| Exit**
 3. Move or delete the file(s)
 4. Restart SmartGit
 
 ### Synchronizing settings when running multiple SmartGit versions in parallel
 
-A common case where you might be running two SmartGit versions in parallel is when having the latest release installed ("*older version*", e.g. 18.2) and you are giving the current preview version a try ("*newer version*", e.g. 19.1). Once you are first installing/starting the *newer version* it will copy over settings from the *older version*. From that point of time, settings will diverge. You may synchronize the settings of the *newer version* from the *older version* at any time by the following procedure:
+A common case where you might be running two SmartGit versions in parallel is when having the latest release installed ("*older version*", e.g. 18.2) and you are giving the current preview version a try ("*newer version*", e.g. 19.1). 
+Once you are first installing/starting the *newer version* it will copy over settings from the *older version*. 
+From that point in time, settings will diverge. 
+You may synchronize the settings of the *newer version* from the *older version* at any time by the following procedure:
 
-1. Start the *older version*, invoke **Help\|About** and from **Information** page and write down the **Settings Path** ("*old settings directory*")
+1. Start the *older version*, invoke **Help \| About** and from **Information** page and write down the **Settings Path** ("*old settings directory*")
 2. Shutdown the *older version*
-3. Start the *newer version,* invoke **Help\|About** and from **Information** page and write down the **Settings Path** ("*new settings directory*")
+3. Start the *newer version,* invoke **Help \| About** and from **Information** page and write down the **Settings Path** ("*new settings directory*")
 4. Shutdown the *newer version*
 5. From the command line or file manager, make a backup of all files from the *new settings directory*, then delete all files to finally have an empty directory
 6. Copy over all files from the *old settings directory* to the *new settings directory*
@@ -68,7 +71,11 @@ A common case where you might be running two SmartGit versions in parallel is wh
 
 ## Program Updates
 
-SmartGit stores program updates which have been downloaded automatically through SmartGit itself by default in your home directory/profile. This allows "light weight", *patch-like* updates which do not require write access to the actual SmartGit installation directory. As a consequence, your SmartGit installation directory is usually not up-to-date, but it will detect and launch the downloaded updates from the `updates` directory. Occasionally, SmartGit will detect that an upgrade of the installation directory itself is necessary ("installation update"). Depending on your operating system, the *updates cache* can be found at:
+SmartGit stores program updates which have been downloaded automatically through SmartGit itself by default in your home directory/profile. 
+This allows "light weight", *patch-like* updates which do not require write access to the actual SmartGit installation directory. 
+As a consequence, your SmartGit installation directory is usually not up-to-date, but it will detect and launch the downloaded updates from the `updates` directory. 
+Occasionally, SmartGit will detect that an upgrade of the installation directory itself is necessary ("installation update"). 
+Depending on your operating system, the *updates cache* can be found at:
 
 - **Windows**: `%APPDATA%\syntevo\SmartGit\updates`
 - **MacOS**: `~/Library/Application Support/SmartGit/updates`

--- a/src/SmartGit/Manual/Installation/Installation-and-Files.md
+++ b/src/SmartGit/Manual/Installation/Installation-and-Files.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Installation-and-Files.html
-  - /SmartGit/Manual/Installation-and-Files
----
-
 # SmartGit Installation File Locations
 
 SmartGit stores its internal settings files independently for each user. 

--- a/src/SmartGit/Manual/Installation/On-premise-license-server.md
+++ b/src/SmartGit/Manual/Installation/On-premise-license-server.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/On-premise-license-server
-  - /SmartGit/Manual/On-premise-license-server.html
----
-
 # On-premise License Server
 
 To monitor seat usage for a large number of users, it may be convenient to install our *On-premise License Server*. An On-Premise License Server will be essential if a firewall or company policy prevents SmartGit installations from connecting to our central cloud license server. Additionally, the bundled frontend is great to quickly monitor the usage of our products within your organization.

--- a/src/SmartGit/Manual/Installation/On-premise-license-server.md
+++ b/src/SmartGit/Manual/Installation/On-premise-license-server.md
@@ -147,7 +147,7 @@ If required, users can configure the license server on-the-fly during setup:
 
 ### Configuration after Setup
 
-If SmartGit has already been started in evaluation mode and you want to switch to the license server, invoke **Help\|Register** and follow the instructions from the above section.
+If SmartGit has already been started in evaluation mode and you want to switch to the license server, invoke **Help \| Register** and follow the instructions from the above section.
 
 ### Distribution of License Files
 

--- a/src/SmartGit/Manual/Installation/On-premise-update-server.md
+++ b/src/SmartGit/Manual/Installation/On-premise-update-server.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/On-premise-update-server
-  - /SmartGit/Manual/On-premise-update-server.html
----
-
 # On-premise update server
 
 If you have a large number of SmartGit installations on your corporate network, it may be convenient to replicate our way of deployment in your company.

--- a/src/SmartGit/Manual/Installation/On-premise-update-server.md
+++ b/src/SmartGit/Manual/Installation/On-premise-update-server.md
@@ -176,7 +176,7 @@ URLs for all files mentioned in the `CONTENT` section will be composed by concat
 `autoupdate` and `control`-files can easily be fetched from our website. To fetch all files listed in the `control` file, you have two options:
 
 - write a script which will fetch all these files from our website and put it onto your update server
-- have a temporary SmartGit installation, let it fetch all necessary files using `Help|Check for New Version` and copy files over from SmartGit's local update "repository" (see [Installation and Files](Installation-and-Files.md)) to your update server.
+- have a temporary SmartGit installation, let it fetch all necessary files using `Help \| Check for New Version` and copy files over from SmartGit's local update "repository" (see [Installation and Files](Installation-and-Files.md)) to your update server.
 
 # Required and helpful SmartGit system properties
 

--- a/src/SmartGit/Manual/Installation/index.md
+++ b/src/SmartGit/Manual/Installation/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Installation
----
 # SmartGit Installation
 
 Please select one of the below topics relating to SmartGit Installation:

--- a/src/SmartGit/Manual/Integrations/Azure-DevOps.md
+++ b/src/SmartGit/Manual/Integrations/Azure-DevOps.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Azure-DevOps
-  - /SmartGit/Manual/Azure-DevOps.html
----
-
 # Azure DevOps
 
 SmartGit integrates Azure DevOps workflows in several places, very similar to [GitHub](GitHub-integration.md) integration. 

--- a/src/SmartGit/Manual/Integrations/BitBucket-Server-Atlassian-Stash-integration.md
+++ b/src/SmartGit/Manual/Integrations/BitBucket-Server-Atlassian-Stash-integration.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/BitBucket-Server-Atlassian-Stash-integration
-  - /SmartGit/Manual/BitBucket-Server-Atlassian-Stash-integration.html
----
-
 # BitBucket Server (Atlassian Stash) integration
 
 SmartGit integrates BitBucket Server (Atlassian Stash) workflows in several places, very similar to the [GitHub](GitHub-integration.md) integration.

--- a/src/SmartGit/Manual/Integrations/Bitbucket-integration.md
+++ b/src/SmartGit/Manual/Integrations/Bitbucket-integration.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Bitbucket-integration
-  - /SmartGit/Manual/Bitbucket-integration.html
----
-
 # Bitbucket integration
 
 SmartGit integrates Bitbucket workflows in various places, very similar to the [GitHub](GitHub-integration.md) integration. 

--- a/src/SmartGit/Manual/Integrations/Gerrit.md
+++ b/src/SmartGit/Manual/Integrations/Gerrit.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Gerrit
-  - /SmartGit/Manual/Gerrit.html
----
-
 # Gerrit
 
 SmartGit provides integration with Gerrit in the *Log* and the *Working Tree* windows. You can invoke the **Push to Gerrit** command in the **Branches** view if a Gerrit remote has been detected. It will offer a dialog with special Gerrit-related Push options.

--- a/src/SmartGit/Manual/Integrations/Git-LFS.md
+++ b/src/SmartGit/Manual/Integrations/Git-LFS.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Git-LFS
-  - /SmartGit/Manual/Git-LFS.html
----
-
 # Git-LFS
 
 SmartGit provides support for common Git Large File Storage (Git-LFS) operations, provided that Git-LFS has been installed on your system and it's configured in your Git config files, so that Git-LFS is already configured and tested to be working from the command line.

--- a/src/SmartGit/Manual/Integrations/Git-LFS.md
+++ b/src/SmartGit/Manual/Integrations/Git-LFS.md
@@ -4,14 +4,15 @@ SmartGit provides support for common Git Large File Storage (Git-LFS) operations
 
 ## Implementing low-level commands
 
-SmartGit implements low-level Git-LFS commands and provides them in the **Local\|LFS** menu. There is almost a 1-1 correspondence between SmartGit commands and Git-LFS command line.
+SmartGit implements low-level Git-LFS commands and provides them in the **Local \| LFS** menu. 
+There is almost a 1-1 correspondence between SmartGit commands and Git-LFS command line.
 
 #### Example: setting up and adding files to Git-LFS
 
 > We are following the [Git-LFS tutorial](https://github.com/git-lfs/git-lfs/wiki/Tutorial) to add a file to Git-LFS:
 >
-> - `git lfs install`: invoke **Local\|LFS\|Install**
-> - `git lfs track <file>`: select an *untracked* file in SmartGit's **Files** view and invoke **Local\|LFS\|Track**;
+> - `git lfs install`: invoke **Local \| LFS \| Install**
+> - `git lfs track <file>`: select an *untracked* file in SmartGit's **Files** view and invoke **Local \| LFS \| Track**;
     > SmartGit suggests a matching pattern for the selected file which you can adjust if necessary
 > - `git add .gitattributes`: right click `.gitattributes` and invoke **Add**
 > - `git add <file>`: right click the file and invoke **Add**

--- a/src/SmartGit/Manual/Integrations/GitHub-Actions.md
+++ b/src/SmartGit/Manual/Integrations/GitHub-Actions.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GitHub-Actions
-  - /SmartGit/Manual/GitHub-Actions.html
----
-
 # GitHub Actions integration (only Standard window)
 
 SmartGit will display GitHub Actions workflow run results in the **My History** view of the

--- a/src/SmartGit/Manual/Integrations/GitHub-Enterprise-Integration.md
+++ b/src/SmartGit/Manual/Integrations/GitHub-Enterprise-Integration.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GitHub-Enterprise-Integration
-  - /SmartGit/Manual/GitHub-Enterprise-Integration.html
----
-
 # GitHub Enterprise Integration
 
 Authenticating to a GitHub Enterprise instance is slightly different than to *github.com* due to the nature of *OAuth*. Basically you have to use **Personal Access Tokens** there. This approach can be performed by an individual user without needing administrative rights for the GitHub Enterprise instance.

--- a/src/SmartGit/Manual/Integrations/GitHub-integration.md
+++ b/src/SmartGit/Manual/Integrations/GitHub-integration.md
@@ -67,7 +67,8 @@ When selecting this *merge* node in the **Commits** view, you can see the entire
 
 For a pull request which had been fetched once, there was a special *ref* created which will make it show up in the **Pull Requests** category, even if it is not present on the server anymore. In this case, you may use **Drop Local** on such a pull request to get rid of the corresponding ref, the local merge commit, all other commits of the pull request and the entry in **Pull Requests** as well. It's safe to use **Drop Local**, as it will only affect the local repository and you can re-fetch a pull request anytime you like using **Fetch** again.
 
-You can invoke **Review\|Sync** to manually update the displayed information. Usually you will want to do that, if you know that server-side information has changed since the Log has been opened.
+You can invoke **Review \| Sync** to manually update the displayed information. 
+Usually you will want to do that, if you know that server-side information has changed since the Log has been opened.
 
 To create a pull request, use **Create Pull Request** from the context menu of the **Branches** view.
 
@@ -154,7 +155,9 @@ Typical Git error messages hinting to this kind of problem:
 
 ### Distributed Reviews interference
 
-When using GitHub, be sure to have [Distributed Reviews](../AddOns/Distributed-Reviews-add-on-.md) disabled for your repository, otherwise there may be confusion about GitHub vs. Distributed Reviews pull requests. To be sure to have Distributed Reviews disabled, invoke **Review\|Configure**:
+When using GitHub, be sure to have [Distributed Reviews](../AddOns/Distributed-Reviews-add-on-.md) disabled for your repository, 
+otherwise there may be confusion about GitHub vs. Distributed Reviews pull requests. 
+To be sure to have Distributed Reviews disabled, invoke **Review \| Configure**:
 
 - if SmartGit asks you whether to initialize the Review database, Distributed Reviews are not enabled (as it should be). Select **Cancel** to keep it disabled.
 - if SmartGit asks you what to configure, Distributed Reviews are enabled. Select **Dispose Database** to disable it.

--- a/src/SmartGit/Manual/Integrations/GitHub-integration.md
+++ b/src/SmartGit/Manual/Integrations/GitHub-integration.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GitHub-integration
-  - /SmartGit/Manual/GitHub-integration.html
----
-
 # GitHub integration
 
 SmartGit integrates GitHub workflows in various places, provided that the connection to *github.com* or a custom *GitHub Enterprise instance* has been configured in the Preferences.

--- a/src/SmartGit/Manual/Integrations/GitLab.md
+++ b/src/SmartGit/Manual/Integrations/GitLab.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/GitLab
-  - /SmartGit/Manual/GitLab.html
----
-
 # GitLab
 
 SmartGit integrates GitLab workflows in various places, very similar to [GitHub](GitHub-integration.md) integration. Some behavior can be customized by [low-level properties](../GUI/AdvancedSettings/System-Properties.md).

--- a/src/SmartGit/Manual/Integrations/JIRA.md
+++ b/src/SmartGit/Manual/Integrations/JIRA.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/JIRA
-  - /SmartGit/Manual/JIRA.html
----
-
 # JIRA
 
 The SmartGit integration to Atlassian JIRA allows you to select a commit message (including JIRA key) directly from (open) JIRA issues and to optionally mark issues as resolved on **Push**.

--- a/src/SmartGit/Manual/Integrations/Jenkins.md
+++ b/src/SmartGit/Manual/Integrations/Jenkins.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Jenkins
-  - /SmartGit/Manual/Jenkins.html
----
-
 # Jenkins integration (Standard Window only)
 
 SmartGit will display Jenkins job results in the **My History** view of *Standard* window, if configured. Currently, *free style projects* and *multibranch pipelines* are supported.

--- a/src/SmartGit/Manual/Integrations/TeamCity.md
+++ b/src/SmartGit/Manual/Integrations/TeamCity.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/TeamCity
-  - /SmartGit/Manual/TeamCity.html
----
-
 # TeamCity integration (Standard Window only)
 
 SmartGit will display JetBrains TeamCity build results in the **My History** view of the [*Standard Window*](../GUI/Standard-Window.md), if configured.

--- a/src/SmartGit/Manual/Integrations/index.md
+++ b/src/SmartGit/Manual/Integrations/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Integrations
----
 # SmartGit Integrations with other Applications and Git Hosting Services
 
 SmartGit works with most modern Git Hosting services, and can also be used with popular Issue Tracking systems. Please select one of the below topics for further information:

--- a/src/SmartGit/Manual/Licensing/Commercial-only-features.md
+++ b/src/SmartGit/Manual/Licensing/Commercial-only-features.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Commercial-only-features
-  - /SmartGit/Manual/Commercial-only-features.html
----
-
 # Commercial-only features
 
 A commercial license is in general required when running SmartGit in a commercial environment, see sections 3.2.1 and 3.2.2 of the [license agreement](https://www.syntevo.com/documents/smartgit-license.html).

--- a/src/SmartGit/Manual/Licensing/Hobby-Use-License.md
+++ b/src/SmartGit/Manual/Licensing/Hobby-Use-License.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Hobby-Use-License
-  - /SmartGit/Manual/Hobby-Use-License.html
----
-
 # Hobby-Use License
 
 The Hobby-Use license limits repository access to specific conditions. Every accessed repository (including submodules) must satisfy at least one of these conditions.

--- a/src/SmartGit/Manual/Licensing/index.md
+++ b/src/SmartGit/Manual/Licensing/index.md
@@ -1,7 +1,3 @@
----
-redirect_from:
-  - /SmartGit/Manual/Licensing
----
 # SmartGit Licensing
 
 For an overview of how to find the most suitable licensing option for SmartGit for your situation, please consult [SmartGit Licensing](../../HowTos/Licensing.md)


### PR DESCRIPTION
Re-issue PR for items 28/29/34:

I've chained 3 commits https://github.com/syntevo/docs/commits/feature/34-FixMenuPipes/ for consideration for merging.
 
28 - changes.maximumFileSize - the original commit was still in the repo. I've added a bit more cross linking and as requested, most of the info is in the changes View. I've kept the setting in the Low Level Properties as I guess we are trying to build a definitive reference / index - users will want to see items where they expect them.
 
29 - Remove all redirects
 
34 - I noted that I'd missed a couple of backslashes to escape Menu \| Navigation style instructions.
This makes no differenc in GitHub repo markdown, but it Jekyll incorrectly renders this as a table e.g.
https://docs.syntevo.com/SmartGit/Latest/Manual/GUI/Branch/Conflict-Solver
There's some whitespace changes too - I broke some very long lines up. It makes no difference to the rendered content, but it makes the markdown easier to maintain.
 