### PR TITLE
SmartGit index: don't link SmartGit to website

### DIFF
--- a/src/SmartGit/index.md
+++ b/src/SmartGit/index.md
@@ -1,12 +1,13 @@
 # SmartGit documentation
 
-If you are new to [SmartGit](https://www.syntevo.com/smartgit/), the [SmartGit User Interface Reference](Manual/GUI/index.md) is a good place to start.
+If you are new to SmartGit, the [SmartGit User Interface Reference](Manual/GUI/index.md) is a good place to start.
 
 This documentation is split into two sections, and each serves a distinct purpose:
 - [Manual](Manual/index.md) 
-  This section of the documentation offers an in-depth reference guide to [SmartGit's](https://www.syntevo.com/smartgit/) features and functionality. It provides comprehensive descriptions of the software's tools, menus, options, and overall workflows.
+  This section of the documentation offers an in-depth reference guide to SmartGit's features and functionality.
+  It provides comprehensive descriptions of the software's tools, menus, options, and overall workflows.
 - [How Tos](HowTos/index.md)
-  This section focuses on specific, task-oriented guides that show how to perform particular actions within [SmartGit](https://www.syntevo.com/smartgit/). It is presented in a step-by-step format, making it clear and actionable.
-  
-In short, the [Manual](Manual/index.md) is a comprehensive feature reference, while the [How Tos](HowTos/index.md) section provides practical guides for particular tasks within [SmartGit](https://www.syntevo.com/smartgit/).
+  This section focuses on specific, task-oriented guides that show how to perform particular actions within SmartGit.
+  It is presented in a step-by-step format, making it clear and actionable.
 
+In short, the [Manual](Manual/index.md) is a comprehensive feature reference, while the [How Tos](HowTos/index.md) section provides practical guides for particular tasks within SmartGit.


### PR DESCRIPTION
One likely way of the user to access the documentation is to reach it from syntevo.com/smartgit/. If every word "SmartGit" is a link back the SmartGit website, it hampers the flow of reading. IMHO it is sufficient to have the SmartGit icon in the top bar being a link.